### PR TITLE
Add long_cycles_with_context

### DIFF
--- a/src/scheduler.ml
+++ b/src/scheduler.ml
@@ -47,6 +47,13 @@ let long_cycles t ~at_least =
       then Tail.extend tail t.last_cycle_time))
 ;;
 
+let long_cycles_with_context t ~at_least =
+  Stream.create (fun tail ->
+    run_every_cycle_start t ~f:(fun () ->
+      if Time_ns.Span.( >= ) t.last_cycle_time at_least
+      then Tail.extend tail (t.last_cycle_time,t.current_execution_context)))
+;;
+
 let cycle_num_jobs t =
   Stream.create (fun tail ->
     run_every_cycle_start t ~f:(fun () -> Tail.extend tail t.last_cycle_num_jobs))

--- a/src/scheduler.mli
+++ b/src/scheduler.mli
@@ -42,6 +42,7 @@ val set_check_invariants : t -> bool -> unit
 val set_record_backtraces : t -> bool -> unit
 val run_every_cycle_start : t -> f:(unit -> unit) -> unit
 val long_cycles : t -> at_least:Time_ns.Span.t -> Time_ns.Span.t Async_stream.t
+val long_cycles_with_context : t -> at_least:Time_ns.Span.t -> (Time_ns.Span.t * Execution_context.t) Async_stream.t
 val can_run_a_job : t -> bool
 val create_alarm : t -> (unit -> unit) -> Gc.Expert.Alarm.t
 val add_finalizer : t -> 'a Heap_block.t -> ('a Heap_block.t -> unit) -> unit


### PR DESCRIPTION
Adds a call `long_async_cycles_with_context`, like `long_async_cycles` but also returns the current execution context, which contains backtraces.

Not clear this is the execution context we want, though. Maybe we have to save one somewhere to reveal information about the long cycle.