### PR TITLE
Add Monitor.exn_to_error

### DIFF
--- a/src/monitor.ml
+++ b/src/monitor.ml
@@ -243,6 +243,20 @@ let send_exn t ?backtrace exn =
   loop t
 ;;
 
+let exn_to_error exn =
+  match exn with
+  | Error_ {exn; backtrace; _} ->
+    let backtrace =
+      match backtrace with
+      | Some backtrace -> `This (Backtrace.to_string backtrace)
+      | None -> `Get
+    in
+    Error.tag ~tag:"monitor.ml.Error"
+      (Error.of_exn ~backtrace exn)
+  | exn ->
+    Error.of_exn ~backtrace:`Get exn
+;;
+
 module Exported_for_scheduler = struct
   let within_context context f =
     Scheduler.(with_execution_context (t ())) context ~f:(fun () ->

--- a/src/monitor.mli
+++ b/src/monitor.mli
@@ -92,6 +92,12 @@ val get_next_error : t -> exn Deferred.t
     backtrace from the error (see discussion in [try_with]). *)
 val extract_exn : exn -> exn
 
+(** [exn_to_error] extracts the exn from an error exn that comes from a monitor,
+    repackaging it into an [Error.t]. If it is not supplied such an error exn, the
+    backtrace is inferred and the exn is packaged as given.
+*)
+val exn_to_error : exn -> Error.t
+
 (** [has_seen_error t] returns true iff the monitor has ever seen an error. *)
 val has_seen_error : t -> bool
 


### PR DESCRIPTION
This lets us use the backtrace provided by monitor exceptions without having to go through an ugly exn -> sexp -> string -> json conversion when logging.