### PR TITLE
Expose  `here` field in monitors

### DIFF
--- a/src/monitor.mli
+++ b/src/monitor.mli
@@ -56,6 +56,7 @@ val name : t -> Info.t
 
 val parent : t -> t option
 val depth : t -> int
+val here : t -> Source_code_position.t option
 
 (** [current ()] returns the current monitor. *)
 val current : unit -> t


### PR DESCRIPTION
The `here` field in monitors has been available by `deriving fields`, but then made unavailable by `monitor.mli`.

Make that field available again.